### PR TITLE
compability with iOS version accept URI as input and return array of predictions; fix for issue #10

### DIFF
--- a/android/src/main/java/com/visioncameraplugininatvision/VisionCameraPluginInatVisionModule.java
+++ b/android/src/main/java/com/visioncameraplugininatvision/VisionCameraPluginInatVisionModule.java
@@ -135,6 +135,7 @@ public class VisionCameraPluginInatVisionModule extends ReactContextBaseJavaModu
         List<Prediction> predictions = classifier.classifyFrame(bitmap);
         bitmap.recycle();
 
+        WritableMap result = Arguments.createMap();
         WritableArray results = Arguments.createArray();
 
         for (Prediction prediction : predictions) {
@@ -144,6 +145,7 @@ public class VisionCameraPluginInatVisionModule extends ReactContextBaseJavaModu
             results.pushMap(map);
         }
 
-        promise.resolve(results);
+        result.putArray("predictions", results);
+        promise.resolve(result);
     }
 }


### PR DESCRIPTION
These changes fix issue #10:

- accept URI as input just as the iOS version does
- check return value of `BitmapFactory.decodeFile()` for `null`; don't pass `null` to `getWidth()` anymore
- return array of predictions just as the iOS version does