### PR TITLE
Switch to bilinear filter when rescaling Bitmap

### DIFF
--- a/android/src/main/java/com/visioncameraplugininatvision/VisionCameraPluginInatVisionPlugin.java
+++ b/android/src/main/java/com/visioncameraplugininatvision/VisionCameraPluginInatVisionPlugin.java
@@ -126,7 +126,7 @@ public class VisionCameraPluginInatVisionPlugin extends FrameProcessorPlugin {
         croppedBitmap,
         ImageClassifier.DIM_IMG_SIZE_X,
         ImageClassifier.DIM_IMG_SIZE_Y,
-        false);
+        true);
       bmp.recycle();
       bmp = rescaledBitmap;
       Log.d(TAG, "getBitmap: " + bmp + ": " + bmp.getWidth() + " x " + bmp.getHeight());


### PR DESCRIPTION
This changes the algorithm used for rescaling the Bitmap in the Android native part of the plugin to use bilinear filter. This closes #12 .

Draft for now, as it is in alpha testing in Seek and iNatRN.