### PR TITLE
Taxonomy rollup cutoff with a threshold

### DIFF
--- a/android/src/main/java/com/visioncameraplugininatvision/ImageClassifier.java
+++ b/android/src/main/java/com/visioncameraplugininatvision/ImageClassifier.java
@@ -69,6 +69,13 @@ public class ImageClassifier {
         return mTaxonomy.getNegativeFilter();
     }
 
+    public void setTaxonomyRollupCutoff(float taxonomyRollupCutoff) {
+        mTaxonomy.setTaxonomyRollupCutoff(taxonomyRollupCutoff);
+    }
+
+    public float getTaxonomyRollupCutoff() {
+        return mTaxonomy.getTaxonomyRollupCutoff();
+    }
 
     /** Initializes an {@code ImageClassifier}. */
     public ImageClassifier(String modelPath, String taxonomyPath, String version) throws IOException {

--- a/android/src/main/java/com/visioncameraplugininatvision/Taxonomy.java
+++ b/android/src/main/java/com/visioncameraplugininatvision/Taxonomy.java
@@ -87,6 +87,17 @@ public class Taxonomy {
         return mNegativeFilter;
     }
 
+    public void setTaxonomyRollupCutoff(float taxonomyRollupCutoff) {
+        if (mTaxonomyRollupCutoff != taxonomyRollupCutoff) {
+            Timber.tag(TAG).d("setTaxonomyRollupCutoff: changing taxonomyRollupCutoff from " + mTaxonomyRollupCutoff + " to " + taxonomyRollupCutoff);
+        }
+        mTaxonomyRollupCutoff = taxonomyRollupCutoff;
+    }
+
+    public float getTaxonomyRollupCutoff() {
+        return mTaxonomyRollupCutoff;
+    }
+
     Taxonomy(InputStream is, String version) {
         mModelVersion = version;
         // Read the taxonomy CSV file into a list of nodes

--- a/android/src/main/java/com/visioncameraplugininatvision/Taxonomy.java
+++ b/android/src/main/java/com/visioncameraplugininatvision/Taxonomy.java
@@ -189,7 +189,9 @@ public class Taxonomy {
 
                 }
             }
-            allScores.put(currentNode.key, thisScore);
+            if (thisScore != 0.0f) {
+              allScores.put(currentNode.key, thisScore);
+            }
 
         } else {
             // base case, no children

--- a/android/src/main/java/com/visioncameraplugininatvision/Taxonomy.java
+++ b/android/src/main/java/com/visioncameraplugininatvision/Taxonomy.java
@@ -181,7 +181,7 @@ public class Taxonomy {
                 Map<String, Float> childScores = aggregateScores(results, child);
                 if (childScores.containsKey(child.key)) {
                   float childScore = childScores.get(child.key);
-                  if (childScore > mTaxonomyRollupCutoff) {
+                  if (childScore >= mTaxonomyRollupCutoff) {
                     allScores.putAll(childScores);
                     thisScore += childScore;
                   }
@@ -205,7 +205,7 @@ public class Taxonomy {
             }
 
             float leafScore = results[Integer.valueOf(currentNode.leafId)];
-            if (leafScore > mTaxonomyRollupCutoff) {
+            if (leafScore >= mTaxonomyRollupCutoff) {
               allScores.put(currentNode.key, resetScore ? 0.0f : leafScore);
             }
         }

--- a/android/src/main/java/com/visioncameraplugininatvision/Taxonomy.java
+++ b/android/src/main/java/com/visioncameraplugininatvision/Taxonomy.java
@@ -193,7 +193,7 @@ public class Taxonomy {
 
         } else {
             // base case, no children
-            boolean resetScore = false;
+            boolean filterOut = false;
 
             if (mFilterByTaxonId != null) {
                 // Filter
@@ -202,12 +202,12 @@ public class Taxonomy {
                 // A) Negative filter + prediction does contain taxon ID as ancestor
                 // B) Non-negative filter + prediction does not contain taxon ID as ancestor
                 boolean containsAncestor = hasAncestor(currentNode, mFilterByTaxonId.toString());
-                resetScore = (containsAncestor && mNegativeFilter) || (!containsAncestor && !mNegativeFilter);
+                filterOut = (containsAncestor && mNegativeFilter) || (!containsAncestor && !mNegativeFilter);
             }
 
             float leafScore = results[Integer.valueOf(currentNode.leafId)];
-            if (leafScore >= mTaxonomyRollupCutoff) {
-              allScores.put(currentNode.key, resetScore ? 0.0f : leafScore);
+            if (!filterOut && leafScore >= mTaxonomyRollupCutoff) {
+              allScores.put(currentNode.key, leafScore);
             }
         }
 

--- a/android/src/main/java/com/visioncameraplugininatvision/Taxonomy.java
+++ b/android/src/main/java/com/visioncameraplugininatvision/Taxonomy.java
@@ -63,8 +63,7 @@ public class Taxonomy {
     private Integer mFilterByTaxonId = null; // If null -> no filter by taxon ID defined
     private boolean mNegativeFilter = false;
 
-    // TODO: default to 0
-    private float mTaxonomyRollupCutoff = 0.01f;
+    private float mTaxonomyRollupCutoff = 0.0f;
 
     public void setFilterByTaxonId(Integer taxonId) {
         if (mFilterByTaxonId != taxonId) {

--- a/android/src/main/java/com/visioncameraplugininatvision/Taxonomy.java
+++ b/android/src/main/java/com/visioncameraplugininatvision/Taxonomy.java
@@ -159,6 +159,7 @@ public class Taxonomy {
         float[] results = ((float[][]) outputs.get(0))[0];
 
         Map<String, Float> scores = aggregateScores(results);
+        Timber.tag(TAG).d("Number of nodes in scores: " + scores.size());
         List<Prediction> bestBranch = buildBestBranchFromScores(scores);
 
         return bestBranch;

--- a/android/src/main/java/com/visioncameraplugininatvision/Taxonomy.java
+++ b/android/src/main/java/com/visioncameraplugininatvision/Taxonomy.java
@@ -63,6 +63,7 @@ public class Taxonomy {
     private Integer mFilterByTaxonId = null; // If null -> no filter by taxon ID defined
     private boolean mNegativeFilter = false;
 
+    // TODO: default to 0
     private float mTaxonomyRollupCutoff = 0.01f;
 
     public void setFilterByTaxonId(Integer taxonId) {

--- a/android/src/main/java/com/visioncameraplugininatvision/VisionCameraPluginInatVisionModule.java
+++ b/android/src/main/java/com/visioncameraplugininatvision/VisionCameraPluginInatVisionModule.java
@@ -175,7 +175,7 @@ public class VisionCameraPluginInatVisionModule extends ReactContextBaseJavaModu
 
         WritableMap resultMap = Arguments.createMap();
         resultMap.putArray("predictions", cleanedPredictions);
-        resultMap.putString("uri", uri.toString());
+        resultMap.putMap("options", options);
         promise.resolve(resultMap);
     }
 }

--- a/android/src/main/java/com/visioncameraplugininatvision/VisionCameraPluginInatVisionPlugin.java
+++ b/android/src/main/java/com/visioncameraplugininatvision/VisionCameraPluginInatVisionPlugin.java
@@ -104,12 +104,12 @@ public class VisionCameraPluginInatVisionPlugin extends FrameProcessorPlugin {
 
     Boolean negativeFilter = (Boolean)arguments.get("negativeFilter");
     if (negativeFilter != null) {
-      setNegativeFilter(negativeFilter != null ? negativeFilter : false);
+      setNegativeFilter(negativeFilter);
     }
 
     Double taxonomyRollupCutoff = (Double)arguments.get("taxonomyRollupCutoff");
     if (taxonomyRollupCutoff != null) {
-      setTaxonomyRollupCutoff(taxonomyRollupCutoff != null ? taxonomyRollupCutoff.floatValue() : null);
+      setTaxonomyRollupCutoff(taxonomyRollupCutoff.floatValue());
     }
 
     Double cropRatio = (Double)arguments.get("cropRatio");

--- a/android/src/main/java/com/visioncameraplugininatvision/VisionCameraPluginInatVisionPlugin.java
+++ b/android/src/main/java/com/visioncameraplugininatvision/VisionCameraPluginInatVisionPlugin.java
@@ -46,6 +46,14 @@ public class VisionCameraPluginInatVisionPlugin extends FrameProcessorPlugin {
       }
   }
 
+  private float mTaxonomyRollupCutoff = 0.01f;
+  public void setTaxonomyRollupCutoff(float taxonomyRollupCutoff) {
+      mTaxonomyRollupCutoff = taxonomyRollupCutoff;
+      if (mImageClassifier != null) {
+        mImageClassifier.setTaxonomyRollupCutoff(mTaxonomyRollupCutoff);
+      }
+  }
+
   private double mCropRatio = 1.0;
   public void setCropRatio(double cropRatio) {
       mCropRatio = cropRatio;
@@ -97,6 +105,11 @@ public class VisionCameraPluginInatVisionPlugin extends FrameProcessorPlugin {
     Boolean negativeFilter = (Boolean)arguments.get("negativeFilter");
     if (negativeFilter != null) {
       setNegativeFilter(negativeFilter != null ? negativeFilter : false);
+    }
+
+    Double taxonomyRollupCutoff = (Double)arguments.get("taxonomyRollupCutoff");
+    if (taxonomyRollupCutoff != null) {
+      setTaxonomyRollupCutoff(taxonomyRollupCutoff != null ? taxonomyRollupCutoff.floatValue() : null);
     }
 
     Double cropRatio = (Double)arguments.get("cropRatio");

--- a/android/src/main/java/com/visioncameraplugininatvision/VisionCameraPluginInatVisionPlugin.java
+++ b/android/src/main/java/com/visioncameraplugininatvision/VisionCameraPluginInatVisionPlugin.java
@@ -46,6 +46,7 @@ public class VisionCameraPluginInatVisionPlugin extends FrameProcessorPlugin {
       }
   }
 
+  // TODO: default to 0 like on iOS
   private float mTaxonomyRollupCutoff = 0.01f;
   public void setTaxonomyRollupCutoff(float taxonomyRollupCutoff) {
       mTaxonomyRollupCutoff = taxonomyRollupCutoff;

--- a/android/src/main/java/com/visioncameraplugininatvision/VisionCameraPluginInatVisionPlugin.java
+++ b/android/src/main/java/com/visioncameraplugininatvision/VisionCameraPluginInatVisionPlugin.java
@@ -98,9 +98,7 @@ public class VisionCameraPluginInatVisionPlugin extends FrameProcessorPlugin {
 
     // Destructure optional parameters and set values
     String filterByTaxonId = (String)arguments.get("filterByTaxonId");
-    if (filterByTaxonId != null) {
-      setFilterByTaxonId(filterByTaxonId != null ? Integer.valueOf(filterByTaxonId) : null);
-    }
+    setFilterByTaxonId(filterByTaxonId != null ? Integer.valueOf(filterByTaxonId) : null);
 
     Boolean negativeFilter = (Boolean)arguments.get("negativeFilter");
     if (negativeFilter != null) {

--- a/android/src/main/java/com/visioncameraplugininatvision/VisionCameraPluginInatVisionPlugin.java
+++ b/android/src/main/java/com/visioncameraplugininatvision/VisionCameraPluginInatVisionPlugin.java
@@ -46,8 +46,7 @@ public class VisionCameraPluginInatVisionPlugin extends FrameProcessorPlugin {
       }
   }
 
-  // TODO: default to 0 like on iOS
-  private float mTaxonomyRollupCutoff = 0.01f;
+  private float mTaxonomyRollupCutoff = 0.0f;
   public void setTaxonomyRollupCutoff(float taxonomyRollupCutoff) {
       mTaxonomyRollupCutoff = taxonomyRollupCutoff;
       if (mImageClassifier != null) {

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -152,6 +152,7 @@ export default function App(): React.JSX.Element {
             modelPath,
             taxonomyPath,
             confidenceThreshold,
+            taxonomyRollupCutoff: 0.001,
             filterByTaxonId,
             negativeFilter,
             numStoredResults: 4,

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -45,9 +45,9 @@ export default function App(): React.JSX.Element {
   const location = useLocationPermission();
 
   const [results, setResult] = useState<InatVision.Prediction[]>([]);
-  const [filterByTaxonId, setFilterByTaxonId] = useState<undefined | string>(
-    undefined
-  );
+  const [filterByTaxonId, setFilterByTaxonId] = useState<
+    undefined | string | null
+  >(undefined);
   const [negativeFilter, setNegativeFilter] = useState(false);
 
   enum VIEW_STATUS {
@@ -70,7 +70,7 @@ export default function App(): React.JSX.Element {
     if (!filterByTaxonId) {
       setFilterByTaxonId('47126');
     } else {
-      setFilterByTaxonId(undefined);
+      setFilterByTaxonId(null);
     }
   };
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -162,6 +162,7 @@ export default function App(): React.JSX.Element {
           const timeAfter = new Date().getTime();
           console.log('time taken ms: ', timeAfter - timeBefore);
           console.log('age of result: ', timeAfter - cvResult.timestamp);
+          console.log('cvResult.timeElapsed', cvResult.timeElapsed);
           handleResults(cvResult.predictions);
         } catch (classifierError) {
           console.log(`Error: ${classifierError}`);
@@ -212,6 +213,7 @@ export default function App(): React.JSX.Element {
         const timeAfter = new Date().getTime();
         console.log('time taken ms: ', timeAfter - timeBefore);
         console.log('Result', JSON.stringify(result));
+        console.log('result.timeElapsed', result.timeElapsed);
         setResult(result.predictions);
       })
       .catch((err) => {

--- a/ios/Classifier/VCPTaxonomy.h
+++ b/ios/Classifier/VCPTaxonomy.h
@@ -15,9 +15,10 @@
 
 @property BOOL linneanPredictionsOnly;
 
+@property float taxonomyRollupCutoff;
+
 - (instancetype)initWithTaxonomyFile:(NSString *)taxaFile;
 - (VCPPrediction *)inflateTopPredictionFromClassification:(MLMultiArray *)classification confidenceThreshold:(float)threshold;
 - (NSArray *)inflateTopBranchFromClassification:(MLMultiArray *)classification;
-- (void)setTaxonomyRollupCutoff:(float)taxonomyRollupCutoff;
 
 @end

--- a/ios/Classifier/VCPTaxonomy.h
+++ b/ios/Classifier/VCPTaxonomy.h
@@ -18,5 +18,6 @@
 - (instancetype)initWithTaxonomyFile:(NSString *)taxaFile;
 - (VCPPrediction *)inflateTopPredictionFromClassification:(MLMultiArray *)classification confidenceThreshold:(float)threshold;
 - (NSArray *)inflateTopBranchFromClassification:(MLMultiArray *)classification;
+- (void)setTaxonomyRollupCutoff:(float)taxonomyRollupCutoff;
 
 @end

--- a/ios/Classifier/VCPTaxonomy.m
+++ b/ios/Classifier/VCPTaxonomy.m
@@ -85,7 +85,7 @@
             }
         }
 
-        self.taxonomyRollupCutoff = 0.01;
+        self.taxonomyRollupCutoff = 0.0;
     }
 
     return self;

--- a/ios/Classifier/VCPTaxonomy.m
+++ b/ios/Classifier/VCPTaxonomy.m
@@ -116,6 +116,8 @@
 
 - (NSArray *)inflateTopBranchFromClassification:(MLMultiArray *)classification {
     NSDictionary *scores = [self aggregateScores:classification];
+    // Log number of nodes in scores
+    NSLog(@"Number of nodes in scores: %lu", (unsigned long)scores.count);
     return [self buildBestBranchFromScores:scores];
 }
 

--- a/ios/Classifier/VCPTaxonomy.m
+++ b/ios/Classifier/VCPTaxonomy.m
@@ -16,7 +16,6 @@
 // this is a convenience array for testing
 @property NSArray *leaves;
 @property VCPNode *life;
-@property float taxonomyRollupCutoff;
 @end
 
 @implementation VCPTaxonomy
@@ -98,9 +97,6 @@
     self.nodesByTaxonId = nil;
 }
 
-- (void)setTaxonomyRollupCutoff:(float)taxonomyRollupCutoff {
-    _taxonomyRollupCutoff = taxonomyRollupCutoff;
-}
 
 - (NSDictionary *)leafScoresFromClassification:(MLMultiArray *)classification {
     NSMutableDictionary *scores = [NSMutableDictionary dictionary];

--- a/ios/Classifier/VCPTaxonomy.m
+++ b/ios/Classifier/VCPTaxonomy.m
@@ -99,7 +99,6 @@
 }
 
 - (void)setTaxonomyRollupCutoff:(float)taxonomyRollupCutoff {
-    NSAssert(taxonomyRollupCutoff >= 0.0 && taxonomyRollupCutoff <= 1.0, @"taxonomyRollupCutoff must be between 0.0 and 1.0");
     _taxonomyRollupCutoff = taxonomyRollupCutoff;
 }
 

--- a/ios/Classifier/VCPTaxonomy.m
+++ b/ios/Classifier/VCPTaxonomy.m
@@ -155,9 +155,9 @@
                 thisScore += [childScore floatValue];
             }
         }
-        // TODO: does it make sense to not add the node if it's score is 0?
-        allScores[node.taxonId] = @(thisScore);
-
+        if (thisScore > 0) {
+          allScores[node.taxonId] = @(thisScore);
+        }
     } else {
         // base case, no children
         NSAssert(node.leafId, @"node with taxonId %@ has no children but also has no leafId", node.taxonId);

--- a/ios/Classifier/VCPTaxonomy.m
+++ b/ios/Classifier/VCPTaxonomy.m
@@ -16,6 +16,7 @@
 // this is a convenience array for testing
 @property NSArray *leaves;
 @property VCPNode *life;
+@property float taxonomyRollupCutoff;
 @end
 
 @implementation VCPTaxonomy
@@ -83,6 +84,8 @@
                 [self.life addChild:node];
             }
         }
+        
+        self.taxonomyRollupCutoff = 0.01;   
     }
 
     return self;
@@ -133,32 +136,33 @@
 // following
 // https://github.com/inaturalist/inatVisionAPI/blob/multiclass/inferrers/multi_class_inferrer.py#L136
 - (NSDictionary *)aggregateScores:(MLMultiArray *)classification currentNode:(VCPNode *)node {
+    NSMutableDictionary *allScores = [NSMutableDictionary dictionary];
+
     if (node.children.count > 0) {
-        // we'll populate this and return it
-        NSMutableDictionary *allScores = [NSMutableDictionary dictionary];
-
-        for (VCPNode *child in node.children) {
-            NSDictionary *childScores = [self aggregateScores:classification currentNode:child];
-            [allScores addEntriesFromDictionary:childScores];
-        }
-
         float thisScore = 0.0f;
         for (VCPNode *child in node.children) {
-            thisScore += [allScores[child.taxonId] floatValue];
+            NSDictionary *childScores = [self aggregateScores:classification currentNode:child];
+            NSNumber *childScore = childScores[child.taxonId];
+            
+            if ([childScore floatValue] > self.taxonomyRollupCutoff) {
+                [allScores addEntriesFromDictionary:childScores];
+                thisScore += [childScore floatValue];
+            }
         }
-
         allScores[node.taxonId] = @(thisScore);
 
-        return [NSDictionary dictionaryWithDictionary:allScores];
     } else {
         // base case, no children
         NSAssert(node.leafId, @"node with taxonId %@ has no children but also has no leafId", node.taxonId);
         NSNumber *leafScore = [classification objectAtIndexedSubscript:node.leafId.integerValue];
         NSAssert(leafScore, @"node with leafId %@ has no score", node.leafId);
-        return @{
-            node.taxonId: leafScore
-        };
+        
+        if ([leafScore floatValue] > self.taxonomyRollupCutoff) {
+            allScores[node.taxonId] = leafScore;
+        }
     }
+    
+    return [allScores copy];
 }
 
 - (NSDictionary *)aggregateScores:(MLMultiArray *)classification {

--- a/ios/Classifier/VCPTaxonomy.m
+++ b/ios/Classifier/VCPTaxonomy.m
@@ -149,11 +149,12 @@
             NSDictionary *childScores = [self aggregateScores:classification currentNode:child];
             NSNumber *childScore = childScores[child.taxonId];
 
-            if ([childScore floatValue] > self.taxonomyRollupCutoff) {
+            if ([childScore floatValue] >= self.taxonomyRollupCutoff) {
                 [allScores addEntriesFromDictionary:childScores];
                 thisScore += [childScore floatValue];
             }
         }
+        // TODO: does it make sense to not add the node if it's score is 0?
         allScores[node.taxonId] = @(thisScore);
 
     } else {
@@ -162,7 +163,7 @@
         NSNumber *leafScore = [classification objectAtIndexedSubscript:node.leafId.integerValue];
         NSAssert(leafScore, @"node with leafId %@ has no score", node.leafId);
 
-        if ([leafScore floatValue] > self.taxonomyRollupCutoff) {
+        if ([leafScore floatValue] >= self.taxonomyRollupCutoff) {
             allScores[node.taxonId] = leafScore;
         }
     }

--- a/ios/Classifier/VCPTaxonomy.m
+++ b/ios/Classifier/VCPTaxonomy.m
@@ -98,6 +98,11 @@
     self.nodesByTaxonId = nil;
 }
 
+- (void)setTaxonomyRollupCutoff:(float)taxonomyRollupCutoff {
+    NSAssert(taxonomyRollupCutoff >= 0.0 && taxonomyRollupCutoff <= 1.0, @"taxonomyRollupCutoff must be between 0.0 and 1.0");
+    _taxonomyRollupCutoff = taxonomyRollupCutoff;
+}
+
 - (NSDictionary *)leafScoresFromClassification:(MLMultiArray *)classification {
     NSMutableDictionary *scores = [NSMutableDictionary dictionary];
 

--- a/ios/Classifier/VCPTaxonomy.m
+++ b/ios/Classifier/VCPTaxonomy.m
@@ -84,8 +84,8 @@
                 [self.life addChild:node];
             }
         }
-        
-        self.taxonomyRollupCutoff = 0.01;   
+
+        self.taxonomyRollupCutoff = 0.01;
     }
 
     return self;
@@ -143,7 +143,7 @@
         for (VCPNode *child in node.children) {
             NSDictionary *childScores = [self aggregateScores:classification currentNode:child];
             NSNumber *childScore = childScores[child.taxonId];
-            
+
             if ([childScore floatValue] > self.taxonomyRollupCutoff) {
                 [allScores addEntriesFromDictionary:childScores];
                 thisScore += [childScore floatValue];
@@ -156,12 +156,12 @@
         NSAssert(node.leafId, @"node with taxonId %@ has no children but also has no leafId", node.taxonId);
         NSNumber *leafScore = [classification objectAtIndexedSubscript:node.leafId.integerValue];
         NSAssert(leafScore, @"node with leafId %@ has no score", node.leafId);
-        
+
         if ([leafScore floatValue] > self.taxonomyRollupCutoff) {
             allScores[node.taxonId] = leafScore;
         }
     }
-    
+
     return [allScores copy];
 }
 

--- a/ios/VisionCameraPluginInatVision/VisionCameraPluginInatVision.m
+++ b/ios/VisionCameraPluginInatVision/VisionCameraPluginInatVision.m
@@ -151,13 +151,16 @@
       [bestBranchAsDict addObject:[prediction asDict]];
   }
 
-  // Create a new dictionary with the bestBranchAsDict under the key "predictions"
-  NSDictionary *response = [NSDictionary dictionary];
-  response = @{@"predictions": bestBranchAsDict};
-
   // End timestamp
   NSTimeInterval timeElapsed = [[NSDate date] timeIntervalSinceDate:startDate];
   NSLog(@"inatVision took %f seconds", timeElapsed);
+
+  // Create a new dictionary with the bestBranchAsDict under the key "predictions"
+  NSDictionary *response = [NSDictionary dictionary];
+  response = @{
+    @"predictions": bestBranchAsDict,
+    @"timeElapsed": @(timeElapsed)
+  };
 
   return response;
 }

--- a/ios/VisionCameraPluginInatVision/VisionCameraPluginInatVision.m
+++ b/ios/VisionCameraPluginInatVision/VisionCameraPluginInatVision.m
@@ -108,6 +108,9 @@
 
   // Setup taxonomy
   VCPTaxonomy *taxonomy = [VisionCameraPluginInatVisionPlugin taxonomyWithTaxonomyFile:taxonomyPath];
+  if (taxonomyRollupCutoff) {
+    [taxonomy setTaxonomyRollupCutoff:taxonomyRollupCutoff.floatValue];
+  }
 
   // Setup vision model
   VNCoreMLModel *visionModel = [VisionCameraPluginInatVisionPlugin visionModelWithModelFile:modelPath];

--- a/ios/VisionCameraPluginInatVision/VisionCameraPluginInatVision.m
+++ b/ios/VisionCameraPluginInatVision/VisionCameraPluginInatVision.m
@@ -94,6 +94,8 @@
   NSString* modelPath = arguments[@"modelPath"];
   // Destructure taxonomy path out of options
   NSString* taxonomyPath = arguments[@"taxonomyPath"];
+  // Destructure taxonomyRollupCutoff out of options
+  NSNumber* taxonomyRollupCutoff = arguments[@"taxonomyRollupCutoff"];
 
   CMSampleBufferRef buffer = frame.buffer;
   UIImageOrientation orientation = frame.orientation;

--- a/ios/VisionCameraPluginInatVision/VisionCameraPluginInatVisionModule.m
+++ b/ios/VisionCameraPluginInatVision/VisionCameraPluginInatVisionModule.m
@@ -215,14 +215,18 @@ RCT_EXPORT_METHOD(getPredictionsForImage:(NSDictionary *)options
             [bestRecentBranchAsDict addObject:[prediction asDict]];
         }
 
-        // Create a new dictionary with the bestRecentBranchAsDict under the key "predictions"
-        // and the options passed in under the key "options"
-        NSDictionary *response = [NSDictionary dictionary];
-        response = @{@"predictions": bestRecentBranchAsDict, @"options": options};
-
         // End timestamp
         NSTimeInterval timeElapsed = [[NSDate date] timeIntervalSinceDate:startDate];
         NSLog(@"getPredictionsForImage took %f seconds", timeElapsed);
+
+        // Create a new dictionary with the bestRecentBranchAsDict under the key "predictions"
+        // and the options passed in under the key "options"
+        NSDictionary *response = [NSDictionary dictionary];
+        response = @{
+            @"predictions": bestBranchAsDict,
+            @"options": options,
+            @"timeElapsed": @(timeElapsed),
+        };
 
         resolve(response);
     }

--- a/ios/VisionCameraPluginInatVision/VisionCameraPluginInatVisionModule.m
+++ b/ios/VisionCameraPluginInatVision/VisionCameraPluginInatVisionModule.m
@@ -174,14 +174,18 @@ RCT_EXPORT_METHOD(getPredictionsForImage:(NSDictionary *)options
               [bestRecentBranchAsDict addObject:[prediction asDict]];
           }
 
-          // Create a new dictionary with the bestRecentBranchAsDict under the key "predictions"
-          // and the options passed in under the key "options"
-          NSDictionary *response = [NSDictionary dictionary];
-          response = @{@"predictions": bestRecentBranchAsDict, @"options": options};
-
           // End timestamp
           NSTimeInterval timeElapsed = [[NSDate date] timeIntervalSinceDate:startDate];
           NSLog(@"getPredictionsForImage took %f seconds", timeElapsed);
+
+          // Create a new dictionary with the bestRecentBranchAsDict under the key "predictions"
+          // and the options passed in under the key "options"
+          NSDictionary *response = [NSDictionary dictionary];
+          response = @{
+            @"predictions": bestRecentBranchAsDict,
+            @"options": options,
+            @"timeElapsed": @(timeElapsed),
+          };
 
           resolve(response);
       }];
@@ -223,7 +227,7 @@ RCT_EXPORT_METHOD(getPredictionsForImage:(NSDictionary *)options
         // and the options passed in under the key "options"
         NSDictionary *response = [NSDictionary dictionary];
         response = @{
-            @"predictions": bestBranchAsDict,
+            @"predictions": bestRecentBranchAsDict,
             @"options": options,
             @"timeElapsed": @(timeElapsed),
         };

--- a/ios/VisionCameraPluginInatVision/VisionCameraPluginInatVisionModule.m
+++ b/ios/VisionCameraPluginInatVision/VisionCameraPluginInatVisionModule.m
@@ -175,9 +175,9 @@ RCT_EXPORT_METHOD(getPredictionsForImage:(NSDictionary *)options
           }
 
           // Create a new dictionary with the bestRecentBranchAsDict under the key "predictions"
-          // and the original image URI under the key "uri"
+          // and the options passed in under the key "options"
           NSDictionary *response = [NSDictionary dictionary];
-          response = @{@"predictions": bestRecentBranchAsDict, @"uri": uri};
+          response = @{@"predictions": bestRecentBranchAsDict, @"options": options};
 
           // End timestamp
           NSTimeInterval timeElapsed = [[NSDate date] timeIntervalSinceDate:startDate];
@@ -216,8 +216,9 @@ RCT_EXPORT_METHOD(getPredictionsForImage:(NSDictionary *)options
         }
 
         // Create a new dictionary with the bestRecentBranchAsDict under the key "predictions"
+        // and the options passed in under the key "options"
         NSDictionary *response = [NSDictionary dictionary];
-        response = @{@"predictions": bestRecentBranchAsDict, @"uri": uri};
+        response = @{@"predictions": bestRecentBranchAsDict, @"options": options};
 
         // End timestamp
         NSTimeInterval timeElapsed = [[NSDate date] timeIntervalSinceDate:startDate];

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -179,11 +179,15 @@ export interface Prediction {
   spatial_class_id?: number;
 }
 
+export interface ResultForImage {
+  options: OptionsForImage;
+  predictions: Prediction[];
+}
+
 export interface Result {
   options: Options;
-  timestamp: number;
   predictions: Prediction[];
-  uri?: string;
+  timestamp: number;
 }
 
 const supportedVersions = ['1.0', '2.3', '2.4', '2.13'];
@@ -413,7 +417,7 @@ interface OptionsForImage {
  */
 export function getPredictionsForImage(
   options: OptionsForImage
-): Promise<Result> {
+): Promise<ResultForImage> {
   optionsAreValidForImage(options);
   return VisionCameraPluginInatVision.getPredictionsForImage(options);
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -230,7 +230,7 @@ function optionsAreValidForFrame(options: Options): boolean {
       options.taxonomyRollupCutoff < 0 ||
       options.taxonomyRollupCutoff > 1
     ) {
-      // have used INatVisionError here because I can not test it due to issue #36
+      // have not used INatVisionError here because I can not test it due to issue #36
       throw new Error(
         'option taxonomyRollupCutoff must be a number between 0 and 1.'
       );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -180,6 +180,7 @@ export interface Prediction {
 }
 
 export interface Result {
+  options: Options;
   timestamp: number;
   predictions: Prediction[];
   uri?: string;
@@ -224,6 +225,8 @@ function optionsAreValid(options: Options | OptionsForImage): boolean {
 function handleResult(result: any, options: Options): Result {
   'worklet';
 
+  // Add the options to the result
+  result.options = options;
   // Add timestamp to the result
   result.timestamp = new Date().getTime();
   // Add the rank to the predictions if not present

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -188,6 +188,7 @@ export interface Result {
   options: Options;
   predictions: Prediction[];
   timestamp: number;
+  timeElapsed?: number; //iOS only
 }
 
 const supportedVersions = ['1.0', '2.3', '2.4', '2.13'];

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -214,6 +214,10 @@ function optionsAreValid(options: Options | OptionsForImage): boolean {
       );
     }
   }
+  if (options.taxonomyRollupCutoff) {
+    // TODO: validate the taxonomyRollupCutoff
+    // have not done this because I can not test it because issue #36
+  }
   return true;
 }
 
@@ -380,6 +384,7 @@ interface OptionsForImage {
   taxonomyPath: string;
   // Optional
   confidenceThreshold?: number;
+  taxonomyRollupCutoff?: number;
   cropRatio?: number;
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -319,7 +319,7 @@ interface Options {
    * A taxonomy rollup cutoff threshold.
    * As a fraction of 1. After computer vision predictions are returned, this value filters out all nodes with
    * a lower score for the caluclation of the best branch or top predictions.
-   * Defaults to 0.01.
+   * Defaults to 0.0 on iOS and 0.01 on Android.
    */
   taxonomyRollupCutoff?: number;
   /**

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -227,7 +227,9 @@ function optionsAreValidForFrame(options: Options): boolean {
       options.taxonomyRollupCutoff > 1
     ) {
       // have used INatVisionError here because I can not test it due to issue #36
-      throw new Error('option cropRatio must be a number between 0 and 1.');
+      throw new Error(
+        'option taxonomyRollupCutoff must be a number between 0 and 1.'
+      );
     }
   }
   return optionsAreValid(options);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -314,6 +314,13 @@ interface Options {
   /**
    * *Android only.*
    *
+   * Value of cv prediction score for lower of which to exclude nodes from performing the taxonomy rollup.
+   * Defaults to 0.01.
+   */
+  taxonomyRollupCutoff?: number;
+  /**
+   * *Android only.*
+   *
    * The iconic taxon id to filter by.
    */
   filterByTaxonId?: null | string;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -182,6 +182,7 @@ export interface Prediction {
 export interface ResultForImage {
   options: OptionsForImage;
   predictions: Prediction[];
+  timeElapsed?: number; //iOS only
 }
 
 export interface Result {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -322,7 +322,7 @@ interface Options {
    * A taxonomy rollup cutoff threshold.
    * As a fraction of 1. After computer vision predictions are returned, this value filters out all nodes with
    * a lower score for the caluclation of the best branch or top predictions.
-   * Defaults to 0.0 on iOS and 0.01 on Android.
+   * Defaults to 0.0.
    */
   taxonomyRollupCutoff?: number;
   /**

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -215,11 +215,27 @@ function optionsAreValid(options: Options | OptionsForImage): boolean {
       );
     }
   }
-  if (options.taxonomyRollupCutoff) {
-    // TODO: validate the taxonomyRollupCutoff
-    // have not done this because I can not test it because issue #36
-  }
   return true;
+}
+
+function optionsAreValidForFrame(options: Options): boolean {
+  'worklet';
+  if (options.taxonomyRollupCutoff) {
+    if (
+      isNaN(options.taxonomyRollupCutoff) ||
+      options.taxonomyRollupCutoff < 0 ||
+      options.taxonomyRollupCutoff > 1
+    ) {
+      // have used INatVisionError here because I can not test it due to issue #36
+      throw new Error('option cropRatio must be a number between 0 and 1.');
+    }
+  }
+  return optionsAreValid(options);
+}
+
+function optionsAreValidForImage(options: OptionsForImage): boolean {
+  'worklet';
+  return optionsAreValid(options);
 }
 
 function handleResult(result: any, options: Options): Result {
@@ -372,7 +388,7 @@ export function inatVision(frame: Frame, options: Options): Result {
   if (plugin === undefined) {
     throw new INatVisionError("Couldn't find the 'inatVision' plugin.");
   }
-  optionsAreValid(options);
+  optionsAreValidForFrame(options);
   // @ts-expect-error Frame Processors are not typed.
   const result = plugin.call(frame, options);
   const handledResult: Result = handleResult(result, options);
@@ -387,7 +403,6 @@ interface OptionsForImage {
   taxonomyPath: string;
   // Optional
   confidenceThreshold?: number;
-  taxonomyRollupCutoff?: number;
   cropRatio?: number;
 }
 
@@ -397,6 +412,6 @@ interface OptionsForImage {
 export function getPredictionsForImage(
   options: OptionsForImage
 ): Promise<Result> {
-  optionsAreValid(options);
+  optionsAreValidForImage(options);
   return VisionCameraPluginInatVision.getPredictionsForImage(options);
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -312,9 +312,9 @@ interface Options {
    */
   confidenceThreshold?: number;
   /**
-   * *Android only.*
-   *
-   * Value of cv prediction score for lower of which to exclude nodes from performing the taxonomy rollup.
+   * A taxonomy rollup cutoff threshold.
+   * As a fraction of 1. After computer vision predictions are returned, this value filters out all nodes with
+   * a lower score for the caluclation of the best branch or top predictions.
    * Defaults to 0.01.
    */
   taxonomyRollupCutoff?: number;


### PR DESCRIPTION
This adds a customizable threshold to the computer vision workflow during frame processing.

During the recursive aggregation of scores for the inner taxonomic nodes a threshold is applied and every node with a lower computer vision score is excluded from the set of nodes on which to find the best predictions from.

Technically there is a breaking change in the structure of the returned dictionary for predictions from file but neither Seek nor iNat has destructured the `uri` param, so I will not bump major version.

@alexshepard can you please double check I took the rollup changes on iOS correctly, and how to set the threshold from outside the VCPTaxonomy class.
P.S: I realized that main is broken atm, so I merge this into a previous stable commit.