### PR TITLE
Dynamic taxonomy cutoff and re-normailzation

### DIFF
--- a/android/src/main/java/com/visioncameraplugininatvision/ImageClassifier.java
+++ b/android/src/main/java/com/visioncameraplugininatvision/ImageClassifier.java
@@ -69,14 +69,6 @@ public class ImageClassifier {
         return mTaxonomy.getNegativeFilter();
     }
 
-    public void setTaxonomyRollupCutoff(float taxonomyRollupCutoff) {
-        mTaxonomy.setTaxonomyRollupCutoff(taxonomyRollupCutoff);
-    }
-
-    public float getTaxonomyRollupCutoff() {
-        return mTaxonomy.getTaxonomyRollupCutoff();
-    }
-
     /** Initializes an {@code ImageClassifier}. */
     public ImageClassifier(String modelPath, String taxonomyPath, String version) throws IOException {
         mModelFilename = modelPath;
@@ -94,7 +86,7 @@ public class ImageClassifier {
     }
 
     /** Classifies a frame from the preview stream. */
-    public List<Prediction> classifyFrame(Bitmap bitmap) {
+    public List<Prediction> classifyFrame(Bitmap bitmap, Double taxonomyRollupCutoff) {
         if (mTFlite == null) {
             Timber.tag(TAG).e("Image classifier has not been initialized; Skipped.");
             return null;
@@ -119,7 +111,7 @@ public class ImageClassifier {
         List<Prediction> predictions = null;
         try {
             mTFlite.runForMultipleInputsOutputs(input, expectedOutputs);
-            predictions = mTaxonomy.predict(expectedOutputs);
+            predictions = mTaxonomy.predict(expectedOutputs, taxonomyRollupCutoff);
         } catch (Exception exc) {
             exc.printStackTrace();
             return new ArrayList<Prediction>();

--- a/android/src/main/java/com/visioncameraplugininatvision/Taxonomy.java
+++ b/android/src/main/java/com/visioncameraplugininatvision/Taxonomy.java
@@ -65,7 +65,7 @@ public class Taxonomy {
     private boolean mNegativeFilter = false;
 
     private float mTaxonomyRollupCutoff = 0.0f;
-    private float mExcludedScoreSum = 0.0f;
+    private float mExcludedLeafScoreSum = 0.0f;
 
     public void setFilterByTaxonId(Integer taxonId) {
         if (mFilterByTaxonId != taxonId) {
@@ -173,11 +173,11 @@ public class Taxonomy {
         }
         resultsCopy = null;
 
-        mExcludedScoreSum = 0.0f;
+        mExcludedLeafScoreSum = 0.0f;
         Map<String, Float> scores = aggregateScores(results);
         // Re-normalize all scores with the sum of all remaining leaf scores
         for (String key : scores.keySet()) {
-          scores.put(key, scores.get(key) / (1.0f - mExcludedScoreSum));
+          scores.put(key, scores.get(key) / (1.0f - mExcludedLeafScoreSum));
         }
         Timber.tag(TAG).d("Number of nodes in scores: " + scores.size());
         List<Prediction> bestBranch = buildBestBranchFromScores(scores);
@@ -231,7 +231,7 @@ public class Taxonomy {
             if (!filterOut && leafScore >= mTaxonomyRollupCutoff) {
               allScores.put(currentNode.key, leafScore);
             } else {
-              mExcludedScoreSum += leafScore;
+              mExcludedLeafScoreSum += leafScore;
             }
         }
 

--- a/android/src/main/java/com/visioncameraplugininatvision/Taxonomy.java
+++ b/android/src/main/java/com/visioncameraplugininatvision/Taxonomy.java
@@ -163,10 +163,7 @@ public class Taxonomy {
         float topCombinedScore = resultsCopy[resultsCopy.length - 1];
         float scoreRatioCutoff = 0.001f;
         float cutoff = topCombinedScore * scoreRatioCutoff;
-        // If no mTaxonomyRollupCutoff is set (= 0.0) use this cutoff
-        if (mTaxonomyRollupCutoff == 0.0f) {
-            setTaxonomyRollupCutoff(cutoff);
-        }
+        setTaxonomyRollupCutoff(cutoff);
         // If taxonomy rollup is given from outside use it instead
         if (taxonomyRollupCutoff != null) {
           setTaxonomyRollupCutoff(taxonomyRollupCutoff.floatValue());

--- a/android/src/main/java/com/visioncameraplugininatvision/Taxonomy.java
+++ b/android/src/main/java/com/visioncameraplugininatvision/Taxonomy.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;

--- a/android/src/main/java/com/visioncameraplugininatvision/Taxonomy.java
+++ b/android/src/main/java/com/visioncameraplugininatvision/Taxonomy.java
@@ -157,6 +157,19 @@ public class Taxonomy {
     public List<Prediction> predict(Map<Integer, Object> outputs) {
         // Get raw predictions
         float[] results = ((float[][]) outputs.get(0))[0];
+        // Make a copy of results
+        float[] resultsCopy = results.clone();
+        // Make sure results is sorted by score
+        Arrays.sort(resultsCopy);
+        // Get result with the highest score
+        float topCombinedScore = resultsCopy[resultsCopy.length - 1];
+        float scoreRatioCutoff = 0.001f;
+        float cutoff = topCombinedScore * scoreRatioCutoff;
+        // If no mTaxonomyRollupCutoff is set (= 0.0) use this cutoff
+        if (mTaxonomyRollupCutoff == 0.0f) {
+            setTaxonomyRollupCutoff(cutoff);
+        }
+        resultsCopy = null;
 
         Map<String, Float> scores = aggregateScores(results);
         Timber.tag(TAG).d("Number of nodes in scores: " + scores.size());

--- a/android/src/main/java/com/visioncameraplugininatvision/Taxonomy.java
+++ b/android/src/main/java/com/visioncameraplugininatvision/Taxonomy.java
@@ -96,10 +96,6 @@ public class Taxonomy {
         mTaxonomyRollupCutoff = taxonomyRollupCutoff;
     }
 
-    public float getTaxonomyRollupCutoff() {
-        return mTaxonomyRollupCutoff;
-    }
-
     Taxonomy(InputStream is, String version) {
         mModelVersion = version;
         // Read the taxonomy CSV file into a list of nodes
@@ -156,7 +152,7 @@ public class Taxonomy {
         return mLeaves.size();
     }
 
-    public List<Prediction> predict(Map<Integer, Object> outputs) {
+    public List<Prediction> predict(Map<Integer, Object> outputs, Double taxonomyRollupCutoff) {
         // Get raw predictions
         float[] results = ((float[][]) outputs.get(0))[0];
         // Make a copy of results
@@ -170,6 +166,10 @@ public class Taxonomy {
         // If no mTaxonomyRollupCutoff is set (= 0.0) use this cutoff
         if (mTaxonomyRollupCutoff == 0.0f) {
             setTaxonomyRollupCutoff(cutoff);
+        }
+        // If taxonomy rollup is given from outside use it instead
+        if (taxonomyRollupCutoff != null) {
+          setTaxonomyRollupCutoff(taxonomyRollupCutoff.floatValue());
         }
         resultsCopy = null;
 

--- a/android/src/main/java/com/visioncameraplugininatvision/Taxonomy.java
+++ b/android/src/main/java/com/visioncameraplugininatvision/Taxonomy.java
@@ -173,12 +173,7 @@ public class Taxonomy {
         }
         resultsCopy = null;
 
-        mExcludedLeafScoreSum = 0.0f;
-        Map<String, Float> scores = aggregateScores(results);
-        // Re-normalize all scores with the sum of all remaining leaf scores
-        for (String key : scores.keySet()) {
-          scores.put(key, scores.get(key) / (1.0f - mExcludedLeafScoreSum));
-        }
+        Map<String, Float> scores = aggregateAndNormalizeScores(results);
         Timber.tag(TAG).d("Number of nodes in scores: " + scores.size());
         List<Prediction> bestBranch = buildBestBranchFromScores(scores);
 
@@ -187,8 +182,15 @@ public class Taxonomy {
 
 
     /** Aggregates scores for nodes, including non-leaf nodes (so each non-leaf node has a score of the sum of all its dependents) */
-    private Map<String, Float> aggregateScores(float[] results) {
-        return aggregateScores(results, mLifeNode);
+    private Map<String, Float> aggregateAndNormalizeScores(float[] results) {
+        // Reset the sum of removed leaf scores
+        mExcludedLeafScoreSum = 0.0f;
+        Map<String, Float> scores = aggregateScores(results, mLifeNode);
+        // Re-normalize all scores with the sum of all remaining leaf scores
+        for (String key : scores.keySet()) {
+          scores.put(key, scores.get(key) / (1.0f - mExcludedLeafScoreSum));
+        }
+        return scores;
     }
 
     /** Following: https://github.com/inaturalist/inatVisionAPI/blob/multiclass/inferrers/multi_class_inferrer.py#L136 */

--- a/android/src/main/java/com/visioncameraplugininatvision/VisionCameraPluginInatVisionModule.java
+++ b/android/src/main/java/com/visioncameraplugininatvision/VisionCameraPluginInatVisionModule.java
@@ -152,7 +152,9 @@ public class VisionCameraPluginInatVisionModule extends ReactContextBaseJavaModu
             return;
         }
 
-        List<Prediction> predictions = classifier.classifyFrame(bitmap);
+        // Override the built-in taxonomy cutoff for predictions from file
+        Double taxonomyRollupCutoff = 0.0;
+        List<Prediction> predictions = classifier.classifyFrame(bitmap, taxonomyRollupCutoff);
         bitmap.recycle();
 
 

--- a/android/src/main/java/com/visioncameraplugininatvision/VisionCameraPluginInatVisionPlugin.java
+++ b/android/src/main/java/com/visioncameraplugininatvision/VisionCameraPluginInatVisionPlugin.java
@@ -46,14 +46,6 @@ public class VisionCameraPluginInatVisionPlugin extends FrameProcessorPlugin {
       }
   }
 
-  private float mTaxonomyRollupCutoff = 0.0f;
-  public void setTaxonomyRollupCutoff(float taxonomyRollupCutoff) {
-      mTaxonomyRollupCutoff = taxonomyRollupCutoff;
-      if (mImageClassifier != null) {
-        mImageClassifier.setTaxonomyRollupCutoff(mTaxonomyRollupCutoff);
-      }
-  }
-
   private double mCropRatio = 1.0;
   public void setCropRatio(double cropRatio) {
       mCropRatio = cropRatio;
@@ -106,9 +98,6 @@ public class VisionCameraPluginInatVisionPlugin extends FrameProcessorPlugin {
     }
 
     Double taxonomyRollupCutoff = (Double)arguments.get("taxonomyRollupCutoff");
-    if (taxonomyRollupCutoff != null) {
-      setTaxonomyRollupCutoff(taxonomyRollupCutoff.floatValue());
-    }
 
     Double cropRatio = (Double)arguments.get("cropRatio");
     if (cropRatio != null) {
@@ -157,7 +146,7 @@ public class VisionCameraPluginInatVisionPlugin extends FrameProcessorPlugin {
       bmp.recycle();
       bmp = rescaledBitmap;
       Log.d(TAG, "rescaledBitmap: " + bmp + ": " + bmp.getWidth() + " x " + bmp.getHeight());
-      List<Prediction> predictions = mImageClassifier.classifyFrame(bmp);
+      List<Prediction> predictions = mImageClassifier.classifyFrame(bmp, taxonomyRollupCutoff);
       bmp.recycle();
       Log.d(TAG, "Predictions: " + predictions.size());
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -193,7 +193,7 @@ export default function App(): React.JSX.Element {
             cropRatio: 0.9,
             useGeoModel,
             geoModelPath,
-            location: testLocationEurope,
+            // location: testLocationEurope,
             patchedOrientationAndroid: 'portrait',
           });
           const timeAfter = new Date().getTime();

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -187,7 +187,6 @@ export default function App(): React.JSX.Element {
             modelPath,
             taxonomyPath,
             confidenceThreshold,
-            taxonomyRollupCutoff: 0.001,
             filterByTaxonId,
             negativeFilter,
             numStoredResults: 4,

--- a/ios/VisionCameraPluginInatVision/VisionCameraPluginInatVision.m
+++ b/ios/VisionCameraPluginInatVision/VisionCameraPluginInatVision.m
@@ -174,8 +174,20 @@
         results = visionScores;
     }
 
+    // Get a pointer to the raw data
+    float *dataPointer = (float *)results.dataPointer;
+    NSUInteger count = results.count;
+    // Use vDSP to find the maximum value
+    float topCombinedScore;
+    vDSP_maxv(dataPointer, 1, &topCombinedScore, count);
+    // define some cutoff based on a percentage of the top combined score. Taxa with
+    // scores below the cutoff will be ignored when aggregating scores up the taxonomy
+    float scoreRatioCutoff = 0.001;
+    float cutoff = topCombinedScore * scoreRatioCutoff;
+
     // Setup taxonomy
     VCPTaxonomy *taxonomy = [VisionCameraPluginInatVisionPlugin taxonomyWithTaxonomyFile:taxonomyPath];
+    [taxonomy setTaxonomyRollupCutoff:cutoff];
     if (taxonomyRollupCutoff) {
       [taxonomy setTaxonomyRollupCutoff:taxonomyRollupCutoff.floatValue];
     }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -418,9 +418,10 @@ interface Options extends BaseOptions {
   numStoredResults?: number;
   /**
    * A taxonomy rollup cutoff threshold.
+   * This is supposed to be used mainly for testing purposes. The frame processor pipeline has an inbuilt
+   * cutoff of combined top score * 0.001. Setting a value here will override the inbuilt cutoff.
    * As a fraction of 1. After computer vision predictions are returned, this value filters out all nodes with
-   * a lower score for the caluclation of the best branch or top predictions.
-   * Defaults to 0.0.
+   * a lower score for the calculation of the best branch or top predictions.
    */
   taxonomyRollupCutoff?: number;
   /**


### PR DESCRIPTION
I have added a dynamic cutoff for taxonomy rollup. Using the top score (combined in iOS, vision only in Android becuase no geo model there yet) * 0.001. After aggregating the scores for all nodes the ones that are remaining are normalized again with the sum of all remaining leaf nodes.