### PR TITLE
build(ios): widen podspec source_files glob

### DIFF
--- a/VisionCameraPluginInatVision.podspec
+++ b/VisionCameraPluginInatVision.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platforms    = { :ios => min_ios_version_supported }
   s.source       = { :git => "https://github.com/inaturalist/vision-camera-plugin-inatvision.git", :tag => "#{s.version}" }
 
-  s.source_files = "ios/**/*.{h,m,mm}"
+  s.source_files = "ios/**/*.{h,m,mm,swift,cpp}"
 
   s.dependency "VisionCamera"
 


### PR DESCRIPTION
Include .swift and .cpp in the source_files alternation so future files of those types under ios/ are picked up by CocoaPods without needing another podspec change:

  ios/**/*.{h,m,mm} → ios/**/*.{h,m,mm,swift,cpp}

Purely additive — no .swift or .cpp files exist in ios/ today, so the compiled output is unchanged. Matches react-native-fs.