### PR TITLE
chore(pkg): use object form for repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,10 @@
     "ios",
     "android"
   ],
-  "repository": "https://github.com/inaturalist/vision-camera-plugin-inatvision",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/inaturalist/vision-camera-plugin-inatvision.git"
+  },
   "author": "Johannes Klein <johannes.t.klein@gmail.com> (https://github.com/inaturalist)",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
Switch from the string form to the npm-canonical object form with type/url and the standard git+ URL prefix + .git suffix:

  "repository": {
    "type": "git",
    "url": "git+https://github.com/inaturalist/vision-camera-plugin-inatvision.git"
  }

Matches react-native-fs and npm's documented convention. Tooling that expects to clone from the field (e.g., `npm repo`, third-party analyzers) now gets a directly-usable URL.