### PR TITLE
Export model init to central provider

### DIFF
--- a/ios/Classifier/VCPModelProvider.h
+++ b/ios/Classifier/VCPModelProvider.h
@@ -1,0 +1,24 @@
+//
+//  VCPModelProvider.h
+//  VisionCameraPluginInatVision
+//
+//  Copyright © 2026 iNaturalist. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@class VCPTaxonomy;
+@class VCPGeomodel;
+@class VCPVisionModel;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface VCPModelProvider : NSObject
+
++ (VCPTaxonomy *) taxonomyWithTaxonomyFile:(NSString *)taxonomyPath;
++ (VCPGeomodel *)geomodelWithModelFile:(NSString *)modelPath;
++ (VCPVisionModel *)visionModelWithModelFile:(NSString *)modelPath;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/Classifier/VCPModelProvider.m
+++ b/ios/Classifier/VCPModelProvider.m
@@ -1,0 +1,82 @@
+//
+//  VCPModelProvider.m
+//  VisionCameraPluginInatVision
+//
+//  Copyright © 2026 iNaturalist. All rights reserved.
+//
+
+#import "VCPModelProvider.h"
+
+#import "VCPTaxonomy.h"
+#import "VCPGeomodel.h"
+#import "VCPVisionModel.h"
+
+@implementation VCPModelProvider
+
++ (VCPTaxonomy *)taxonomyWithTaxonomyFile:(NSString *)taxonomyPath {
+    if (taxonomyPath.length == 0) {
+        return nil;
+    }
+
+    static NSMutableDictionary<NSString *, VCPTaxonomy *> *cache = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        cache = [NSMutableDictionary dictionary];
+    });
+
+    VCPTaxonomy *taxonomy = cache[taxonomyPath];
+    if (taxonomy == nil) {
+        taxonomy = [[VCPTaxonomy alloc] initWithTaxonomyFile:taxonomyPath];
+        if (taxonomy != nil) {
+            cache[taxonomyPath] = taxonomy;
+        }
+    }
+
+    return taxonomy;
+}
+
++ (VCPGeomodel *)geomodelWithModelFile:(NSString *)modelPath {
+    if (modelPath.length == 0) {
+        return nil;
+    }
+
+    static NSMutableDictionary<NSString *, VCPGeomodel *> *cache = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        cache = [NSMutableDictionary dictionary];
+    });
+
+    VCPGeomodel *geomodel = cache[modelPath];
+    if (geomodel == nil) {
+        geomodel = [[VCPGeomodel alloc] initWithModelPath:modelPath];
+        if (geomodel != nil) {
+            cache[modelPath] = geomodel;
+        }
+    }
+
+    return geomodel;
+}
+
++ (VCPVisionModel *)visionModelWithModelFile:(NSString *)modelPath {
+    if (modelPath.length == 0) {
+        return nil;
+    }
+
+    static NSMutableDictionary<NSString *, VCPVisionModel *> *cache = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        cache = [NSMutableDictionary dictionary];
+    });
+
+    VCPVisionModel *visionModel = cache[modelPath];
+    if (visionModel == nil) {
+        visionModel = [[VCPVisionModel alloc] initWithModelPath:modelPath];
+        if (visionModel != nil) {
+            cache[modelPath] = visionModel;
+        }
+    }
+
+    return visionModel;
+}
+
+@end

--- a/ios/VisionCameraPluginInatVision/VisionCameraPluginInatVision.m
+++ b/ios/VisionCameraPluginInatVision/VisionCameraPluginInatVision.m
@@ -13,44 +13,12 @@
 #import "VCPGeomodel.h"
 #import "VCPVisionModel.h"
 #import "VCPMLUtils.h"
+#import "VCPModelProvider.h"
 
 @interface VisionCameraPluginInatVisionPlugin : FrameProcessorPlugin
-
-+ (VCPTaxonomy *) taxonomyWithTaxonomyFile:(NSString *)taxonomyPath;
-+ (VCPGeomodel *)geomodelWithModelFile:(NSString *)geomodelPath;
-+ (VCPVisionModel *)visionModelWithModelFile:(NSString *)modelPath;
-
 @end
 
 @implementation VisionCameraPluginInatVisionPlugin
-
-+ (VCPTaxonomy *)taxonomyWithTaxonomyFile:(NSString *)taxonomyPath {
-    static VCPTaxonomy *taxonomy = nil;
-    if (taxonomy == nil) {
-        taxonomy = [[VCPTaxonomy alloc] initWithTaxonomyFile:taxonomyPath];
-    }
-    return taxonomy;
-}
-
-+ (VCPGeomodel *)geomodelWithModelFile:(NSString *)modelPath {
-    static VCPGeomodel *geomodel = nil;
-
-    if (geomodel == nil) {
-        geomodel = [[VCPGeomodel alloc] initWithModelPath:modelPath];
-    }
-
-    return geomodel;
-}
-
-+ (VCPVisionModel *)visionModelWithModelFile:(NSString *)modelPath {
-    static VCPVisionModel *cvModel = nil;
-
-    if (cvModel == nil) {
-        cvModel = [[VCPVisionModel alloc] initWithModelPath:modelPath];
-    }
-
-    return cvModel;
-}
 
 - (instancetype)initWithProxy:(VisionCameraProxyHolder*)proxy
                   withOptions:(NSDictionary* _Nullable)options {
@@ -88,7 +56,7 @@
     if ([arguments objectForKey:@"useGeomodel"] &&
         [[arguments objectForKey:@"useGeomodel"] boolValue])
     {
-        VCPGeomodel *geomodel = [VisionCameraPluginInatVisionPlugin geomodelWithModelFile:geomodelPath];
+        VCPGeomodel *geomodel = [VCPModelProvider geomodelWithModelFile:geomodelPath];
         geomodelPreds = [geomodel predictionsForLat:latitude.floatValue
                                                 lng:longitude.floatValue
                                           elevation:elevation.floatValue];
@@ -102,7 +70,7 @@
     CVImageBufferRef pixelBuffer = CMSampleBufferGetImageBuffer(buffer);
     UIImageOrientation orientation = frame.orientation;
 
-    VCPVisionModel *cvModel = [VisionCameraPluginInatVisionPlugin visionModelWithModelFile:modelPath];
+    VCPVisionModel *cvModel = [VCPModelProvider visionModelWithModelFile:modelPath];
     MLMultiArray *visionScores = [cvModel visionPredictionsForPixelBuffer:pixelBuffer orientation:orientation];
 
     MLMultiArray *results = nil;
@@ -116,7 +84,7 @@
     }
 
     // Setup taxonomy
-    VCPTaxonomy *taxonomy = [VisionCameraPluginInatVisionPlugin taxonomyWithTaxonomyFile:taxonomyPath];
+    VCPTaxonomy *taxonomy = [VCPModelProvider taxonomyWithTaxonomyFile:taxonomyPath];
     [taxonomy deriveTopScoreRatioCutoff:results];
     if (taxonomyRollupCutoff) {
       [taxonomy setTaxonomyRollupCutoff:taxonomyRollupCutoff.floatValue];
@@ -148,4 +116,4 @@
 VISION_EXPORT_FRAME_PROCESSOR(VisionCameraPluginInatVisionPlugin, inatVision)
 
 @end
-
+ 

--- a/ios/VisionCameraPluginInatVision/VisionCameraPluginInatVisionModule.m
+++ b/ios/VisionCameraPluginInatVision/VisionCameraPluginInatVisionModule.m
@@ -9,6 +9,7 @@
 #import "VCPGeomodel.h"
 #import "VCPVisionModel.h"
 #import "VCPMLUtils.h"
+#import "VCPModelProvider.h"
 
 #import <React/RCTBridgeModule.h>
 
@@ -16,43 +17,10 @@
 // maybe there is some kind of name conflict somewhere. So I changed the name to AwesomeModule
 // because it doesn't matter what the name is and it is quite awesome.
 @interface AwesomeModule : NSObject <RCTBridgeModule>
-
-+ (VCPTaxonomy *) taxonomyWithTaxonomyFile:(NSString *)taxonomyPath;
-+ (VCPGeomodel *)geomodelWithModelFile:(NSString *)geomodelPath;
-+ (VCPVisionModel *)visionModelWithModelFile:(NSString *)modelPath;
-
 @end
 
 @implementation AwesomeModule
 RCT_EXPORT_MODULE(VisionCameraPluginInatVision)
-
-+ (VCPTaxonomy *)taxonomyWithTaxonomyFile:(NSString *)taxonomyPath {
-    static VCPTaxonomy *taxonomy = nil;
-    if (taxonomy == nil) {
-        taxonomy = [[VCPTaxonomy alloc] initWithTaxonomyFile:taxonomyPath];
-    }
-    return taxonomy;
-}
-
-+ (VCPGeomodel *)geomodelWithModelFile:(NSString *)modelPath {
-    static VCPGeomodel *geomodel = nil;
-
-    if (geomodel == nil) {
-        geomodel = [[VCPGeomodel alloc] initWithModelPath:modelPath];
-    }
-
-    return geomodel;
-}
-
-+ (VCPVisionModel *)visionModelWithModelFile:(NSString *)modelPath {
-    static VCPVisionModel *cvModel = nil;
-
-    if (cvModel == nil) {
-        cvModel = [[VCPVisionModel alloc] initWithModelPath:modelPath];
-    }
-
-    return cvModel;
-}
 
 RCT_EXPORT_METHOD(getPredictionsForImage:(NSDictionary *)options
                   resolve:(RCTPromiseResolveBlock)resolve
@@ -88,7 +56,7 @@ RCT_EXPORT_METHOD(getPredictionsForImage:(NSDictionary *)options
     if ([options objectForKey:@"useGeomodel"] &&
         [[options objectForKey:@"useGeomodel"] boolValue])
     {
-        VCPGeomodel *geomodel = [AwesomeModule geomodelWithModelFile:geomodelPath];
+        VCPGeomodel *geomodel = [VCPModelProvider geomodelWithModelFile:geomodelPath];
         geomodelPreds = [geomodel predictionsForLat:latitude.floatValue
                                                 lng:longitude.floatValue
                                           elevation:elevation.floatValue];
@@ -97,10 +65,10 @@ RCT_EXPORT_METHOD(getPredictionsForImage:(NSDictionary *)options
     }
 
     // Setup taxonomy
-    VCPTaxonomy *taxonomy = [AwesomeModule taxonomyWithTaxonomyFile:taxonomyPath];
+    VCPTaxonomy *taxonomy = [VCPModelProvider taxonomyWithTaxonomyFile:taxonomyPath];
 
     // Setup vision model
-    VCPVisionModel *cvModel = [AwesomeModule visionModelWithModelFile:modelPath];
+    VCPVisionModel *cvModel = [VCPModelProvider visionModelWithModelFile:modelPath];
 
     // If uri starts with ph://, it's a photo library asset
     if ([uri hasPrefix:@"ph://"]) {
@@ -249,10 +217,10 @@ RCT_EXPORT_METHOD(getPredictionsForLocation:(NSDictionary *)options
     NSNumber *elevation = location[@"elevation"];
 
     // Setup taxonomy
-    VCPTaxonomy *taxonomy = [AwesomeModule taxonomyWithTaxonomyFile:taxonomyPath];
+    VCPTaxonomy *taxonomy = [VCPModelProvider taxonomyWithTaxonomyFile:taxonomyPath];
 
     MLMultiArray *geomodelPreds = nil;
-    VCPGeomodel *geomodel = [AwesomeModule geomodelWithModelFile:geomodelPath];
+    VCPGeomodel *geomodel = [VCPModelProvider geomodelWithModelFile:geomodelPath];
     geomodelPreds = [geomodel predictionsForLat:latitude.floatValue
                                             lng:longitude.floatValue
                                       elevation:elevation.floatValue];


### PR DESCRIPTION
If a client used both frame processor and image processing in one session they ended up with two cv model, geomodel, and taxonomy files in memory.