### PR TITLE
fix: validate image uri in getPredictionsForImage (#32)

### DIFF
--- a/src/__tests__/getPredictionsForImage.js
+++ b/src/__tests__/getPredictionsForImage.js
@@ -3,7 +3,7 @@ import { NativeModules } from 'react-native';
 import { getPredictionsForImage, MODE } from '../index';
 
 const correctOptions = {
-  uri: 'testUri',
+  uri: 'file:///test/photo.jpg',
   version: '1.0',
   modelPath: 'testModelPath',
   taxonomyPath: 'testTaxonomyPath',
@@ -105,9 +105,66 @@ describe('cropRatio', () => {
   });
 });
 
+describe('uri', () => {
+  it('should not throw for a file:// uri', () => {
+    const options = { ...correctOptions, uri: 'file:///foo/bar.jpg' };
+
+    expect(() => getPredictionsForImage(options)).not.toThrowError();
+  });
+
+  it('should not throw for a ph:// uri', () => {
+    const options = {
+      ...correctOptions,
+      uri: 'ph://CC95F08C-88C3-4012-9D6D-64A413D254B3',
+    };
+
+    expect(() => getPredictionsForImage(options)).not.toThrowError();
+  });
+
+  it('should throw an error when uri is missing', () => {
+    const { uri, ...options } = correctOptions;
+
+    expect(() => getPredictionsForImage(options)).toThrowError(
+      'uri must be a non-empty string.',
+    );
+  });
+
+  it('should throw an error when uri is an empty string', () => {
+    const options = { ...correctOptions, uri: '   ' };
+
+    expect(() => getPredictionsForImage(options)).toThrowError(
+      'uri must be a non-empty string.',
+    );
+  });
+
+  it('should throw an error when uri is not a string', () => {
+    const options = { ...correctOptions, uri: 42 };
+
+    expect(() => getPredictionsForImage(options)).toThrowError(
+      'uri must be a non-empty string.',
+    );
+  });
+
+  it('should throw an error when uri is a bare path without a scheme', () => {
+    const options = { ...correctOptions, uri: '/foo/bar.jpg' };
+
+    expect(() => getPredictionsForImage(options)).toThrowError(
+      'uri must include a scheme',
+    );
+  });
+
+  it('should throw an error when uri is a relative path without a scheme', () => {
+    const options = { ...correctOptions, uri: 'testUri' };
+
+    expect(() => getPredictionsForImage(options)).toThrowError(
+      'uri must include a scheme',
+    );
+  });
+});
+
 describe('getPredictionsForImage result handling', () => {
   const baseOptions = {
-    uri: 'testUri',
+    uri: 'file:///test/photo.jpg',
     version: '1.0',
     modelPath: 'testModelPath',
     taxonomyPath: 'testTaxonomyPath',

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -232,6 +232,30 @@ function locationIsValid(location: Location): boolean {
   return true;
 }
 
+/**
+ * URI scheme matcher, e.g. `file://`, `ph://`, `content://`, `assets-library://`.
+ * Per RFC 3986 a scheme is `ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )`.
+ */
+const uriSchemeRegex = /^[a-z][a-z0-9+.-]*:\/\//i;
+
+function uriIsValid(uri: string): boolean {
+  'worklet';
+  if (typeof uri !== 'string' || uri.trim().length === 0) {
+    throw new Error('uri must be a non-empty string.');
+  }
+  // Require a URI scheme. A bare path like "/foo/bar" is parsed to a relative,
+  // schemeless NSURL on iOS, where the classification then completes with blank
+  // results instead of failing. Reject it here with an informative error rather
+  // than letting it silently produce empty predictions. Both platforms expect a
+  // scheme such as `file://` (or `ph://` for the iOS photo library).
+  if (!uriSchemeRegex.test(uri)) {
+    throw new Error(
+      'uri must include a scheme, e.g. "file:///path/to/image.jpg" or "ph://...".',
+    );
+  }
+  return true;
+}
+
 function optionsAreValid(options: Options | OptionsForImage): boolean {
   'worklet';
   if (!supportedVersions.includes(options.version)) {
@@ -282,6 +306,7 @@ function optionsAreValidForFrame(options: Options): boolean {
 
 function optionsAreValidForImage(options: OptionsForImage): boolean {
   'worklet';
+  uriIsValid(options.uri);
   return optionsAreValid(options);
 }
 


### PR DESCRIPTION
Closes #32 (first bullet).

`getPredictionsForImage` does no validation of `options.uri`. As noted in #32, a schemeless path like `/foo/bar` is parsed by iOS into a *relative*, schemeless `NSURL`, so `VNImageRequestHandler` runs the request and **completes with blank
results** rather than erroring, whereas `file:///foo/bar` works. The user just sees empty predictions with no indication that the URI was the problem.

This PR adds a `uriIsValid` check to the JS layer (in `optionsAreValidForImage`, next to the existing `optionsAreValid` / `locationIsValid` validators it mirrors), so the call throws synchronously and informatively when `uri` is:

- missing / `undefined`, empty, whitespace-only, or not a string
  → `uri must be a non-empty string.`
- a path without a scheme (`/foo/bar`, `testUri`)
  → `uri must include a scheme, e.g. "file:///path/to/image.jpg" or "ph://...".`

I deliberately did **not** allowlist specific schemes: iOS and Android accept different sets (`ph://` is iOS photo-library only; Android does `Uri.parse(uri).getPath()` → `BitmapFactory.decodeFile`). Requiring *a* scheme is the single rule that's correct on both platforms and pins down exactly the failure mode in the issue. The regex follows the RFC 3986 scheme grammar.
