### PR TITLE
fix(android): return after rejecting on null bitmap

### DIFF
--- a/android/src/main/java/com/visioncameraplugininatvision/VisionCameraPluginInatVisionModule.java
+++ b/android/src/main/java/com/visioncameraplugininatvision/VisionCameraPluginInatVisionModule.java
@@ -169,6 +169,7 @@ public class VisionCameraPluginInatVisionModule extends ReactContextBaseJavaModu
                 String msg = String.format("Couldn't read image '%s'", uri.toString());
                 Timber.tag(TAG).w(msg);
                 promise.reject("E_IO_EXCEPTION", msg);
+                return;
             }
             Log.d(TAG, "originalBitmap: " + bitmap + ": " + bitmap.getWidth() + " x " + bitmap.getHeight());
             // Crop the center square of the frame with the given crop ratio


### PR DESCRIPTION
`getPredictionsForImage` rejects when `BitmapFactory.decodeFile` returns `null`, but doesn't `return`. The next line dereferences the null bitmap, throwing an NPE that triggers a second `promise.reject`. Adding `return;` makes the unreadable-image case fail cleanly with `E_IO_EXCEPTION`.
