### PR TITLE
fix(ios): handle bare file paths in getPredictionsForImage

### DIFF
--- a/ios/VisionCameraPluginInatVision/VisionCameraPluginInatVisionModule.m
+++ b/ios/VisionCameraPluginInatVision/VisionCameraPluginInatVisionModule.m
@@ -134,7 +134,17 @@ RCT_EXPORT_METHOD(getPredictionsForImage:(NSDictionary *)options
           resolve(response);
       }];
     } else {
-        NSURL *imageURL = [NSURL URLWithString:uri];
+        // `uri` may be a `file://` URL or a bare filesystem path. `URLWithString:`
+        // only parses the former; for a bare path it returns a scheme-less URL that
+        // later fails `CGImageSourceCreateWithURL`, and it returns nil for paths
+        // containing characters that are invalid in a URL (e.g. spaces). Use
+        // `fileURLWithPath:` for anything that isn't already a `file://` URL.
+        NSURL *imageURL;
+        if ([uri hasPrefix:@"file://"]) {
+            imageURL = [NSURL URLWithString:uri];
+        } else {
+            imageURL = [NSURL fileURLWithPath:uri];
+        }
         if (!imageURL) {
             reject(@"invalid_uri", @"Invalid image URI format", nil);
             return;


### PR DESCRIPTION
- `getPredictionsForImage` now resolves bare filesystem paths via `fileURLWithPath:`. `URLWithString:` only parses `file://` URLs; for a bare path it returned a scheme-less URL that later failed `CGImageSourceCreateWithURL` with a misleading error, so valid local images were rejected. `file://` URLs are unchanged.
- Adds a `build-ios` CI job (macOS) that builds the example app for the simulator. The repo had no iOS job, so native Objective-C changes were never compiled in CI.

Note: the CI job validates that the change compiles; runtime/behavioral validation is out of scope here.