### PR TITLE
Android feeds the model a transposed image (accuracy regression vs. iOS)

### DIFF
--- a/android/src/main/java/com/visioncameraplugininatvision/ImageClassifier.java
+++ b/android/src/main/java/com/visioncameraplugininatvision/ImageClassifier.java
@@ -163,15 +163,18 @@ public class ImageClassifier {
         for (int x = 0; x < ImageClassifier.DIM_IMG_SIZE_X; x++) {
             for (int y = 0; y < ImageClassifier.DIM_IMG_SIZE_Y; y++) {
                 int pixel = bitmap.getPixel(x, y);
+                // getPixel(x, y) takes (column, row); store at [row][col] = [y][x] so the
+                // tensor matches the model's expected NHWC layout. Storing at [x][y]
+                // transposed the image, which the iOS Vision/CoreML path never did.
                 if (mModelVersion.equals("1.0")) {
                   // Normalize channel values to [0.0, 1.0] for version 1.0
-                  input[0][x][y][0] = Color.red(pixel) / 255.0f;
-                  input[0][x][y][1] = Color.green(pixel) / 255.0f;
-                  input[0][x][y][2] = Color.blue(pixel) / 255.0f;
+                  input[0][y][x][0] = Color.red(pixel) / 255.0f;
+                  input[0][y][x][1] = Color.green(pixel) / 255.0f;
+                  input[0][y][x][2] = Color.blue(pixel) / 255.0f;
                 } else {
-                  input[0][x][y][0] = Color.red(pixel);
-                  input[0][x][y][1] = Color.green(pixel);
-                  input[0][x][y][2] = Color.blue(pixel);
+                  input[0][y][x][0] = Color.red(pixel);
+                  input[0][y][x][1] = Color.green(pixel);
+                  input[0][y][x][2] = Color.blue(pixel);
                 }
             }
         }


### PR DESCRIPTION
On Android, `ImageClassifier.convertBitmapToByteBuffer` builds the input tensor with the image **transposed** (rows/columns swapped). The model is fed a diagonally-flipped image, which measurably lowers accuracy and confidence. The iOS path (Vision/CoreML) feeds the image in standard orientation, so the two platforms are not classifying the same pixels.

## Root cause

```java
int pixel = bitmap.getPixel(x, y);   // (x = column, y = row)
input[0][x][y][...] = ...;            // stored at [x][y] -> transpose
```
`getPixel(x, y)` is `(column, row)`, but the value is written to `input[0][x][y]`, i.e. column into the height axis and row into the width axis. Because the input is square (299×299) this doesn't crash, it just transposes the image. The expected NHWC layout is `input[0][row][col]` = `input[0][y][x]`.

## Evidence (on-device A/B)

Measured with an instrumented test that runs the real `ImageClassifier` twice on the same 32-image representative set (one common species per iconic group; model `small_2`; center-crop 0.88 → bilinear 299; geomodel off), toggling only the
store index. Android emulator, x86_64, API 36:

| input layout | top-1 | top-5 | mean top-1 conf |
| --- | --- | --- | --- |
| `[x][y]` (current, transposed) | 25/32 = 78.1% | 100% | 0.646 |
| `[y][x]` (fixed, standard)     | 27/32 = 84.4% | 100% | 0.695 |

Net +2 top-1 (fixes 3 images, regresses 1 deer↔deer near-miss) and +0.05 mean confidence; top-5 unchanged. An off-device TFLite reproduction agrees (fixed = 84.4% / 0.689). Both numbers are the same set, so this isolates the transpose.

## Reproduction

Instrumented test (throwaway) ran `ImageClassifier` with a `transposeInput` toggle over 32 labelled images, comparing top-1 to the expected taxon_id. Raw per-image log: `scripts/benchmark/baselines/transpose-ab-emulator-android36.txt`.

Only tested on the `small_2` model, and applied to all models. Let me know if you need a separate check for other models, or restrict the fix to the "model 1.0" branch.